### PR TITLE
Weekly Skill-Repo Analysis — 2026-05-25

### DIFF
--- a/docs/analysis/ANALYSIS-2026-05-25.md
+++ b/docs/analysis/ANALYSIS-2026-05-25.md
@@ -1,0 +1,245 @@
+# Skill-MCP-Claude Analysis — 2026-05-25
+
+## Summary
+
+- **78 skill directories** on disk; `SCHEMA_V1.md` and `METADATA_AUDIT.md` still claim 94 — a 16-skill gap that has been documented since the 2026-05-17 report and remains unfixed.
+- **All 78 directories contain both `SKILL.md` and `_meta.json`** — zero missing-file violations.
+- **Zero `_meta.json` parse errors**; all 78 required fields (`name`, `description`) present in every file; all 78 also carry the extended required fields (`tags`, `sub_skills`, `source`, `type`, `depends_on`, `enhances`, `relevance_tier`, `review_score`, `last_reviewed_at`).
+- **1 persistent SKILL.md frontmatter name mismatch**: `skills/3d-building-advanced/SKILL.md` still declares `name: building-mechanics` (carried forward from prior two reports, unresolved).
+- **51 broken `references/*.md` paths** in SKILL.md bodies — up from 41 at the 2026-05-18 report, no progress.
+- **Test regression worsened**: 186 passed, 2 failed, 215 errors vs. 332 passed, 0 failed, 100 errors on 2026-05-18 — Flask is now also absent from the test environment (in addition to fastmcp), darkening 146 additional tests.
+- The canonical meta schema (PR #13, merged 2026-05-24) introduced a formal JSON Schema at `schema/meta.schema.json`, a Python validator at `core/meta_schema.py`, and Rust + TypeScript conformance tests — a significant positive infrastructure addition.
+- **68 of 78 skills (87%) have never been reviewed** (`last_reviewed_at` is null); the automated daily audit is processing one skill per day at the current rate.
+
+---
+
+## 1. Catalog Health
+
+### 1.1 Skill Directory Count
+
+| Source | Claimed | Actual | Status |
+|--------|---------|--------|--------|
+| Filesystem (`ls -d skills/*/`) | — | **78** | ground truth |
+| `SCHEMA_V1.md` (2025-03-05) | 94 | 78 | **STALE** (-16) |
+| `METADATA_AUDIT.md` | ~94 rows | 78 | **STALE** (-16) |
+| `REVIEW_SUMMARY.md` | "80 skills validated" | 78 | **STALE** (-2) |
+| Prior report (2026-05-18) | 78 | 78 | Correct |
+
+No change from the 2026-05-18 report. The 14 removed stub skills (`Fix 3.6`) are still referenced in multiple docs that have not been updated.
+
+### 1.2 Required Files per Skill Directory
+
+All 78 skill directories contain both `SKILL.md` and `_meta.json`. Zero missing-file violations. This is an improvement from the pre-Fix-3.6 state listed in `METADATA_AUDIT.md` (which recorded 4 skills missing `SKILL.md`).
+
+### 1.3 `_meta.json` Parse Errors
+
+None. All 78 files parse cleanly.
+
+### 1.4 Required Field Compliance
+
+Using `server.py`'s `META_SCHEMA` required list (`name`, `description`, `tags`, `sub_skills`, `source`, `type`) plus the new optional audit fields (`depends_on`, `enhances`, `last_reviewed_at`, `review_score`, `relevance_tier`):
+
+All 78 skills now carry all 11 unique top-level fields. Every skill has the 6 server-required fields and all 5 extended fields. Zero missing-field violations.
+
+**Note**: the canonical `schema/meta.schema.json` (PR #13) designates only `name` and `description` as strictly required — a deliberate relaxation from the server's stricter enforcement. The server's `validate_meta()` at `server.py:58` enforces 6 required fields including `type`, creating a gap between the published schema and the runtime validator. This inconsistency should be documented.
+
+### 1.5 Name-Directory Agreement
+
+One persistent mismatch, unchanged from previous two reports:
+
+| Skill Dir | `_meta.json` `name` | `SKILL.md` frontmatter `name` | Problem |
+|-----------|---------------------|-------------------------------|---------|
+| `3d-building-advanced` | `3d-building-advanced` (correct) | `building-mechanics` | Stale frontmatter name — caught by `server.py:66` at load time |
+
+### 1.6 Referential Integrity
+
+- **`sub_skills` file references**: All 17 sub-skill file references across the 4 skills that use them (`3d-building-advanced`, `building-router`, `dashboard`, `forms-router`) resolve to existing `references/*.md` files on disk. Zero dangling.
+- **`depends_on` and `enhances`**: All entries across all 78 skills resolve to existing skill directories. Zero dangling references.
+- **`sub_skills` internal label naming**: The label `structural-physics-advanced` in `3d-building-advanced/sub_skills` does not match the actual directory `structural-physics` — an internal inconsistency that does not break file lookups but degrades discoverability.
+- **Questionable `depends_on`**: `brainstorming/_meta.json` lists `using-git-worktrees` and `writing-plans` in `depends_on`. The conceptual dependency of brainstorming on git worktrees is semantically dubious (brainstorming is a pre-implementation design process). This appears to be an artifact of the automated review rather than an intentional authorship decision.
+
+### 1.7 Broken Internal Body References (SKILL.md)
+
+51 error-severity broken references in SKILL.md bodies that cite `references/*.md` paths which do not exist on disk — up from 41 at the 2026-05-18 report. No references have been created to fix these.
+
+| Cluster | Skills affected | Broken links |
+|---------|-----------------|-------------|
+| form-* | form-accessibility, form-react, form-security, form-ux-patterns, form-validation, form-vanilla, form-vue | 14 |
+| r3f-* | r3f-drei, r3f-fundamentals, r3f-geometry, r3f-materials, r3f-performance | 13 |
+| shader-* | shader-effects, shader-fundamentals, shader-noise, shader-sdf | 8 |
+| particles-* | particles-gpu, particles-lifecycle, particles-physics | 5 |
+| other | (various) | 11 |
+
+### 1.8 SKILL.md Frontmatter vs `_meta.json` Description Agreement
+
+35 description mismatches persist — identical count to 2026-05-18. No descriptions have been synced. Notable cases:
+- `brand-guidelines`: meta (declarative) vs. frontmatter (behavioral) — the frontmatter version is more useful for auto-selection.
+- `building-router`: meta is more informative than frontmatter.
+
+### 1.9 Type and Tier Distribution
+
+| Type | Count |
+|------|-------|
+| template | 52 |
+| discipline | 13 |
+| router | 10 |
+| creative-engine | 3 |
+
+| Relevance Tier | Count |
+|----------------|-------|
+| A | 3 |
+| B | 6 |
+| C | 1 |
+| null (unreviewed) | 68 |
+
+Tag quality: `backend-dev-guidelines` carries tags `["web", "python", "code-review"]` but the skill is explicitly about Node.js/Express/TypeScript — `python` is wrong and will mislead search.
+
+---
+
+## 2. Per-Skill Review
+
+This run covers the 7 skills touched by daily audit commits since 2026-05-18 plus 8 from a rotating sample (forms cluster, particles, postfx, r3f, document skills) not covered in the prior report.
+
+| Skill | Type | Verdict | Note |
+|-------|------|---------|------|
+| `audio-playback` | template | **SOLID** | "Use when implementing background music, sound effects..." trigger is specific. 507 lines of Tone.js patterns; quick-start, scheduling, transport well-covered. `review_score=60` understates quality. `split-candidate` flag (>500 lines) is valid: Looping and Crossfade sections could move to `references/`. |
+| `audio-reactive` | template | **SOLID** | "Use when creating audio visualizers, music-reactive animations..." — directly actionable. Correct `depends_on` chain. 554 lines; `split-candidate` flag warranted. Accurate `enhances` to `particles-gpu`, `postfx-bloom`, `shader-effects`. |
+| `audio-router` | router | **THIN** | 60-point score and Tier C indicate review system flagged this correctly. All 3 leaves carry strong standalone descriptions; the router adds dispatch overhead with no content value. Candidate for deprecation per `FUTURE.md` router-rethink item. |
+| `aws-skills` | template | **SOLID** | "Use when deploying to AWS, writing Lambda functions..." — exhaustive trigger enumeration. Good CDK project structure. Tags `["infrastructure","deployment","python","scaffolding"]` — `python` is inaccurate; CDK content is TypeScript. |
+| `backend-dev-guidelines` | discipline | **SOLID** | Layered architecture (Routes → Controllers → Services → Repositories) cleanly illustrated with TypeScript examples. Tags `["web","python","code-review"]` are wrong — should be `["typescript","nodejs","architecture"]`. |
+| `brainstorming` | discipline | **SOLID** | Content is strong: structured 3-option proposal format, one-question-at-a-time principle. `depends_on: ["using-git-worktrees", "writing-plans"]` is semantically incorrect — brainstorming does not depend on git worktrees. Automated audit artifact. |
+| `brand-guidelines` | discipline | **THIN** | 73 lines, no scripts or references. Content accurate (Anthropic colors, typography). `no-trigger-cue` flag from audit is correct — meta description lacks "Use when...". Frontmatter description is better and should replace the meta description. |
+| `form-react` | template | **SOLID** | 646 lines of React Hook Form + Zod patterns. Quick-start snippet at `SKILL.md:16-47` is immediately runnable. 3 broken body references (`references/rhf-patterns.md`, `references/tanstack-patterns.md`, `references/migration-guide.md`). `last_reviewed_at` is null despite being a high-traffic skill — should be prioritized in the review queue. |
+| `form-validation` | template | **SOLID** | "Use when implementing form validation for any framework" — broad but appropriate. Zod schema-first patterns, timing patterns, async validation all covered. 3 broken body references. `enhances` chain to `form-react`, `form-vue`, `form-vanilla` is correct. |
+| `particles-physics` | template | **SOLID** | "Use when particles need realistic or artistic motion..." — specific and discovery-friendly. Force integration, attractors/repulsors, turbulence demonstrated with runnable `useFrame` snippets. 2 broken body references (`references/forces.md`, `references/integration.md`). |
+| `postfx-effects` | template | **SOLID** | "Use when adding cinematic polish, retro aesthetics..." — excellent trigger with concrete use-case enumeration. JSX examples for `@react-three/postprocessing` are clean and accurate. `depends_on: ["postfx-composer"]` correctly models the dependency. |
+| `r3f-materials` | template | **SOLID** | "Use when choosing materials, creating custom shaders, or binding dynamic uniforms" — clear. Material comparison table (`SKILL.md:34-40`) is a strong affordance. 2 broken body references (`references/pbr-properties.md`, `references/uniform-types.md`). |
+| `pdf` | template | **STALE** | Meta description is a raw code fragment: "...from pypdf import PdfReader, PdfWr" — truncated import statement leaked into the description field. Frontmatter description is significantly better. The meta description will degrade search quality. Body content (pypdf, pdfplumber) appears correct. |
+| `pptx` | template | **SOLID** | References companion docs and explicitly warns to read them fully first — good practice. Scripts directory present. The "CRITICAL: Read All Documentation First" structure is effective. |
+| `xlsx` | template | **SOLID** | Financial model color-coding standards, formula error prevention, and formatting conventions well-articulated with specific rules. Frontmatter description enumerates 5 concrete trigger scenarios. |
+
+**Summary by verdict**: SOLID: 12, THIN: 2, STALE: 1, OVERLAP: 0.
+
+---
+
+## 3. MCP Server Contract
+
+### 3.1 Skill Discovery
+
+`server.py:23` sets `SKILLS_DIR = Path(__file__).parent / "skills"`. `load_index()` at `server.py:165` iterates `SKILLS_DIR.iterdir()`, reads `_meta.json`, validates via `validate_meta()`, and populates `_INDEX["skills"]`. `build_content_index()` at `server.py:103` additionally indexes `SKILL.md`, `references/*.md`, and `scripts/*.{md,py,js,ts,jsx,tsx}`. Discovery is correct.
+
+The `load_index()` function silently skips skills that fail required-field validation (`server.py:188`): any future skill without `type` will be excluded from the index with no warning surfaced to callers.
+
+### 3.2 Registered MCP Tool Names (10 tools)
+
+| Tool | Registered at |
+|------|--------------|
+| `list_skills` | `server.py:770` |
+| `get_skill` | `server.py:784` |
+| `get_sub_skill` | `server.py:796` |
+| `get_skills_batch` | `server.py:808` |
+| `get_skill_chain` | `server.py:827` |
+| `search_skills` | `server.py:840` |
+| `search_content` | `server.py:853` |
+| `reload_index` | `server.py:867` |
+| `get_stats` | `server.py:877` |
+| `validate_skills` | `server.py:886` |
+
+All 10 tools are registered via `@mcp.tool()` decorators. No tools added or removed since 2026-05-18.
+
+### 3.3 Security Checks
+
+`core/security.py` implements `is_safe_skill_name` and `validate_skill_path`. Both are correctly applied on every filesystem-touching code path:
+- `_get_skill()` (`server.py:368,376`): `is_safe_skill_name(name)` then `validate_skill_path(skill_dir)`
+- `_get_sub_skill()` (`server.py:407,424`): `is_safe_skill_name(domain)` then `validate_skill_path(file_path)`
+- `_get_skill_chain()` (`server.py:463`): `is_safe_skill_name(name)`
+
+`_get_skills_batch()` at `server.py:444` delegates to `_get_skill()` and `_get_sub_skill()` — both gated — so no bypass surface exists. `_list_skills()` and `_search_*` read from the in-memory index and do not require path validation.
+
+### 3.4 Test Suite Results
+
+**Run: 2026-05-25 — `python3 -m pytest -q`**
+
+```
+2 failed, 186 passed, 215 errors in 6.36s
+403 tests collected
+```
+
+**Baseline (`TEST_BASELINE.md`, 2026-03-05)**: 189 passed, 0 failed, 0 errors
+**Prior report (2026-05-18)**: 332 passed, 0 failed, 100 errors
+
+This is a **worsened regression**. Pass count dropped from 332 to 186 — 146 tests newly erroring.
+
+| Category | Count | Root Cause |
+|----------|-------|-----------|
+| `test_server.py` errors | 95 | `ModuleNotFoundError: No module named 'fastmcp'` — unchanged from 2026-05-18 |
+| `test_api.py` errors | ~48 | `ModuleNotFoundError: No module named 'flask'` — **new since 2026-05-18** |
+| `test_app.py` errors | ~36 | `ModuleNotFoundError: No module named 'flask'` — **new since 2026-05-18** |
+| `test_app_helpers.py` errors | 7 | `ModuleNotFoundError: No module named 'flask'` — **new since 2026-05-18** |
+| `test_security.py` errors | ~29 | Both `flask` and `fastmcp` missing |
+| `test_app.py` failures | 2 | `TestIsPortInUse` — `SystemExit: 1` because `skills_manager_app.py` calls `sys.exit(1)` when Flask is missing |
+
+Flask (`flask>=3.0.0`) was present in the environment for the 2026-05-18 run but is now absent. Both `flask` and `fastmcp` are in `requirements.txt` but neither is installed. The 186 passing tests are the subset that do not require either package (`test_audit.py`, `test_core_*`, `test_meta_conformance.py`). **The effective MCP server test coverage is 0%** — all 88 tests from `TEST_BASELINE.md` are currently dark. The total suite now has 403 collected items (vs. 189 at baseline), with new items across `test_audit.py`, `test_core_*`, `test_meta_conformance.py`, and `test_app_helpers.py`.
+
+---
+
+## 4. Docs Accuracy
+
+| Document | Status | Key Issues |
+|----------|--------|-----------|
+| `SCHEMA_V1.md` | **STALE** | Claims 94 skills (actual: 78); lists only `name`/`description` as required (server enforces 6; canonical schema requires 2); omits `type`, `depends_on`, `enhances`, `relevance_tier`, `review_score`, `last_reviewed_at` |
+| `METADATA_AUDIT.md` | **STALE** | Lists ~94 skills including 16 deleted; no columns for `type`, `depends_on`, `enhances`, or audit fields; dated 2025-03-05 |
+| `TEST_BASELINE.md` | **STALE** | Baseline is 189 tests from 2026-03-05; suite now has 403 collected items; 332-pass/100-error state from 2026-05-18 never updated; current 186-pass/215-error state not reflected |
+| `REMEDIATION_PLAN.md` | **ACCURATE** | All Tier 0–3 items marked DONE; accurately reflects the codebase; no open items |
+| `SECURITY_REVIEW_FINDINGS.md` | **ACCURATE** | All critical/high fixes confirmed applied; valid as historical record |
+| `SKILL_CLASSIFICATION.md` | **PARTIALLY STALE** | Lists 12 router skills including `building` and `forms` (both removed in Fix 3.6); actual router count is 10 |
+| `COMPOSITION_MAP.md` | **PARTIALLY STALE** | References deleted `building` and `forms` skills in the Routers table |
+| `FUTURE.md` | **ACCURATE** | All items remain open; router architecture rethink still pending despite daily audit recommending deprecation of all 10 routers |
+| `REVIEW_SUMMARY.md` | **STALE** | Shows "80 skills" and still references issues resolved in Tier 0–1 |
+
+**Open items not tracked in `REMEDIATION_PLAN.md`**: frontmatter name mismatch in `3d-building-advanced`, 51 broken reference stubs, and missing `fastmcp`/`flask` packages in the test environment.
+
+---
+
+## 5. New Skill Ideas
+
+| Proposed Name | Description | Type | Enhances |
+|---------------|-------------|------|---------|
+| `github-actions` | CI/CD workflow authoring: job matrices, reusable workflows, caching strategies, environment secrets, artifact management, and deployment triggers. Fills the cicd SDLC gap from `FUTURE.md`. | template | `test-driven-development`, `aws-skills`, `mcp-builder` |
+| `r3f-animation` | Animation patterns specific to React Three Fiber: `useFrame` loop timing, `@react-spring/three` for physics-driven animation, `framer-motion-3d`, and GSAP-R3F integration via refs. The R3F cluster (5 skills) has no animation-focused leaf. | template | `r3f-fundamentals`, `gsap-react`, `r3f-performance` |
+| `audio-synthesis` | Tone.js synthesis: oscillators, filters, envelopes, effects chains (reverb, delay, distortion), polyphonic patterns, and generative melody sequencing. The audio cluster covers analysis/playback/reactivity but has no sound-generation leaf. | template | `audio-reactive`, `algorithmic-art`, `gsap-sequencing` |
+| `e2e-testing` | Playwright-based end-to-end testing: page object models, fixture management, visual regression, accessibility audits, network mocking, and CI integration. Fills the testing SDLC gap from `FUTURE.md`. | template | `test-driven-development`, `github-actions`, `frontend-dev-guidelines` |
+| `api-design` | REST and GraphQL API design discipline: resource modeling, pagination patterns, versioning strategy, error schemas, OpenAPI/AsyncAPI documentation, and rate-limiting contracts. Complements `backend-dev-guidelines` at the contract layer. | discipline | `backend-dev-guidelines`, `mcp-builder`, `software-architecture` |
+| `observability-setup` | Application observability: OpenTelemetry instrumentation, structured JSON logging, Sentry error tracking, health-check endpoints, and distributed tracing. Fills the monitoring SDLC gap from `FUTURE.md`. | template | `backend-dev-guidelines`, `aws-skills` |
+
+---
+
+## Diff vs Previous Report (2026-05-18)
+
+- **Skill count**: unchanged at 78.
+- **Type distribution**: unchanged — creative-engine=3, discipline=13, router=10, template=52.
+- **Daily audit commits (2026-05-19 through 2026-05-25)**: one `_meta.json` updated per day: `audio-playback` → `audio-reactive` → `audio-router` → `aws-skills` → `backend-dev-guidelines` → `brainstorming` → `brand-guidelines`. Each received `last_reviewed_at`, `review_score=60`, and `relevance_tier`. No SKILL.md content was changed.
+- **PR #13 (canonical meta contract, merged 2026-05-24)**: Added `schema/meta.schema.json`, `core/meta_schema.py`, TypeScript validator at `skills-mcp-server/src/schemas/meta.ts`, and Rust conformance tests at `rust/skills-mcp/tests/meta_conformance.rs`. Added `jsonschema>=4.0.0` to `requirements.txt`.
+- **PR #12 (baseUrl fix, merged ~2026-05-23)**: Updated baseUrl for API service to support local development.
+- **Test environment regression**: Flask is now absent from the environment, dropping the passing count from 332 to 186. Both `flask` and `fastmcp` are in `requirements.txt` but neither is installed in the test environment.
+- **Broken references**: increased from 41 to 51 — no stubs have been created.
+- **Description mismatches**: unchanged at 35.
+
+---
+
+## Recommended Actions (ranked: severity × 1/effort)
+
+| Priority | Action | Severity | Effort |
+|----------|--------|----------|--------|
+| 1 | **Install `flask` and `fastmcp`** in the test environment (`pip install flask flask-cors flask-limiter fastmcp`). Flask has gone missing since 2026-05-18, dropping pass count by 146. Both are in `requirements.txt` — this is CI environment drift, not a code issue. | Critical | Trivial |
+| 2 | **Fix `3d-building-advanced/SKILL.md` frontmatter name**: change `building-mechanics` → `3d-building-advanced`. Third consecutive report flagging this. | High | Trivial |
+| 3 | **Create 51 missing reference stubs** across form-* (14 refs), r3f-* (13 refs), shader-* (8 refs), particles-* (5 refs), and other clusters (11 refs). Every body link pointing to these returns 404 at runtime. | High | Medium |
+| 4 | **Fix `backend-dev-guidelines` tags**: replace `["web","python","code-review"]` with `["typescript","nodejs","express","architecture"]`. The current tags include `python` for a Node.js skill. | Medium | Trivial |
+| 5 | **Fix `aws-skills` tags**: replace `python` with `typescript` — the CDK content is TypeScript, not Python. | Medium | Trivial |
+| 6 | **Fix `brainstorming` `depends_on`**: remove `using-git-worktrees` — brainstorming does not logically depend on git worktrees. Appears to be an automated audit artifact introduced 2026-05-24. | Medium | Trivial |
+| 7 | **Fix `pdf` meta description**: replace truncated import fragment with a real "Use when..." description. The current value will degrade MCP search quality. | Medium | Trivial |
+| 8 | **Sync 35 description mismatches**: for each of the 35 flagged skills, choose the better description (often the SKILL.md frontmatter version) and copy to `_meta.json`. Directly improves MCP search quality since `server.py` indexes `_meta.json` descriptions. | Medium | Medium |
+| 9 | **Align `server.py` `META_SCHEMA` with `schema/meta.schema.json`**: canonical schema (PR #13) requires only `name` and `description`; `server.py:48` requires 6 fields including `type`. Either update the canonical schema to mark `type` required, or update `server.py` to be more permissive. | Medium | Low |
+| 10 | **Update `SCHEMA_V1.md`**: correct skill count to 78, add `type`/`depends_on`/`enhances`/`relevance_tier`/`review_score`/`last_reviewed_at` field definitions, note that canonical source of truth is now `schema/meta.schema.json`. | Medium | Low |
+| 11 | **Update `TEST_BASELINE.md`**: document the 403-test suite, the missing-dependency root cause, and the 186-passing-test floor that reflects the non-flask/non-fastmcp subset. | Low | Low |
+| 12 | **Evaluate router deprecation**: all 10 routers flagged by daily audit as having strong-description leaves with no weak-description dependents. Consider deprecating `audio-router`, `particles-router`, `postfx-router` as a first pass. | Low | Medium |


### PR DESCRIPTION
## Weekly LLM Skill-Repo Health Analysis — 2026-05-25

This PR adds the scheduled weekly analysis report at `docs/analysis/ANALYSIS-2026-05-25.md`. No source code, skills, or existing docs were modified.

## Key findings

- **Skill count**: 78 skill directories on disk (SCHEMA_V1.md still claims 94 — gap unresolved since 2026-05-17)
- **Tests**: `2 failed, 186 passed, 215 errors` — regression worsened vs. prior report (332 passed). Flask is now missing from the test environment in addition to fastmcp, darkening 146 more tests. **Effective MCP server test coverage: 0%.**
- **Catalog**: Zero parse errors, zero dangling references, all 78 skills have both required files. 1 persistent name mismatch (`3d-building-advanced/SKILL.md` still declares `building-mechanics`) — third consecutive report flagging this.
- **Broken body references**: 51 broken `references/*.md` links (up from 41), no stubs created.
- **Positive**: PR #13 (merged 2026-05-24) added formal JSON Schema, Python validator, and Rust/TypeScript conformance tests — significant infrastructure improvement.
- **Per-skill review**: 15 skills reviewed — 12 SOLID, 2 THIN (`audio-router`, `brand-guidelines`), 1 STALE (`pdf` — truncated import in meta description).
- **New skill ideas proposed**: 6 — `github-actions`, `r3f-animation`, `audio-synthesis`, `e2e-testing`, `api-design`, `observability-setup`

## Top recommended actions

1. **[Critical/Trivial]** Install `flask` and `fastmcp` in the test environment — both are in `requirements.txt` but absent, causing 215 errors.
2. **[High/Trivial]** Fix `3d-building-advanced/SKILL.md` frontmatter name (`building-mechanics` → `3d-building-advanced`).
3. **[High/Medium]** Create 51 missing `references/*.md` stubs.
4. **[Medium/Trivial]** Fix wrong `python` tag in `backend-dev-guidelines` and `aws-skills`.

https://claude.ai/code/session_01PRuYTjhUkF7XTfv9rh7toJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRuYTjhUkF7XTfv9rh7toJ)_